### PR TITLE
MAINT: fixed small typos in SDGs descriptions

### DIFF
--- a/product-schema.json
+++ b/product-schema.json
@@ -397,7 +397,7 @@
           ],
           [
             3,
-            "Good Health and Well-being"
+            "Good Health and Well-Being"
           ],
           [
             4,
@@ -421,11 +421,11 @@
           ],
           [
             9,
-            "Industry, Innovation, and Infrastructure"
+            "Industry, Innovation and Infrastructure"
           ],
           [
             10,
-            "Reducing Inequality"
+            "Reduced Inequalities"
           ],
           [
             11,
@@ -449,7 +449,7 @@
           ],
           [
             16,
-            "Peace, Justice, and Strong Institutions"
+            "Peace, Justice and Strong Institutions"
           ],
           [
             17,


### PR DESCRIPTION
We have observed small discrepancies in the precise wording of the SDGs. The original list was taken from the [Wikipedia entry](https://en.wikipedia.org/wiki/Sustainable_Development_Goals), yet UN sources differ slightly, and we're using UN sources as the the legitimate source; see [1](https://sustainabledevelopment.un.org/sdgs), [2](https://www.un.org/sustainabledevelopment/sustainable-development-goals/) or [3](https://www.undp.org/content/undp/en/home/sustainable-development-goals.html)