### PR TITLE
BLD: make required fields in organizations

### DIFF
--- a/product-schema.json
+++ b/product-schema.json
@@ -561,8 +561,14 @@
     },
     "organizations": {
       "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
       "items": {
         "type": "object",
+        "required": [
+          "name",
+          "org_type"
+        ],
         "properties": {
           "name": {
             "type": "string",


### PR DESCRIPTION
Even though the `organizations` property was required, there were no fields within that property that were required. This PR addresses this shortcoming by requiring `name` and `org_type` within each organization.