### PR TITLE
BLD: added content as type category

### DIFF
--- a/product-schema.json
+++ b/product-schema.json
@@ -543,14 +543,15 @@
     },
     "type": {
       "type": "array",
-      "description": "List of categories under which this Global Digital Public Good falls into: software, data, standards.",
+      "description": "List of categories under which this Global Digital Public Good falls into: content, data, software, standards.",
       "minItems": 1,
       "uniqueItems": true,
       "items": {
         "type": "string",
         "enum": [
-          "software",
+          "content",
           "data",
+          "software",
           "standard"
         ]
       }


### PR DESCRIPTION
Introducing a new `type`: `content` which is different from `data`. Content is typically licensed under a Creative Commons license, whereas data is understood as datasets, and typically uses other licenses.

To further clarify, here are the definitions that we are proposing to use to distinguish the two:
* `Data`: Information coded into a digital form that is efficient for movement or processing by computers.
* `Content`: Information or knowledge that is easily understood directly by people in a relevant context.

This change was implemented on April 15, 2020 in the [unicef/publicgoods-candidates](https://github.com/unicef/publicgoods-candidates/)  repository in [this commit](https://github.com/unicef/publicgoods-candidates/commit/e463aed080b42c31fa01fad09172b52b457974df).