### PR TITLE
BLD: added required "stage" field

### DIFF
--- a/product-schema.json
+++ b/product-schema.json
@@ -10,7 +10,8 @@
     "license",
     "organizations",
     "SDGs",
-    "type"
+    "type",
+    "stage"
   ],
   "properties": {
     "name": {
@@ -600,6 +601,14 @@
           }
         }
       }
+    },
+    "stage": {
+      "type": "string",
+      "enum": [
+        "nominee",
+        "candidate",
+        "DPG"
+      ]
     }
   }
 }


### PR DESCRIPTION
Added new required field `stage`, which is an enum [`nominee`, `candidate`, `DPG`] to capture the stage of this product along the vetting process. The intent is to be able to differentiate and highlight those products that have been fully vetted as Digital Public Goods, see the top chart at https://digitalpublicgoods.net/platform