### PR TITLE
BLD: added "SDGevidence" field

### DIFF
--- a/product-schema.json
+++ b/product-schema.json
@@ -461,6 +461,10 @@
         ]
       }
     },
+    "SDGevidence": {
+      "type": "string",
+      "description": "Relevant links or information to support the relevance to SDGs."
+    }, 
     "sectors": {
       "type": "array",
       "description": "List of sectors that this Global Digital Public Good addresses.",

--- a/product-schema.json
+++ b/product-schema.json
@@ -388,83 +388,45 @@
       "minItems": 1,
       "uniqueItems": true,
       "items": {
-        "type": "array",
-        "enum": [
-          [
-            1,
-            "No Poverty"
-          ],
-          [
-            2,
-            "Zero Hunger"
-          ],
-          [
-            3,
-            "Good Health and Well-Being"
-          ],
-          [
-            4,
-            "Quality Education"
-          ],
-          [
-            5,
-            "Gender Equality"
-          ],
-          [
-            6,
-            "Clean Water and Sanitation"
-          ],
-          [
-            7,
-            "Affordable and Clean Energy"
-          ],
-          [
-            8,
-            "Decent Work and Economic Growth"
-          ],
-          [
-            9,
-            "Industry, Innovation and Infrastructure"
-          ],
-          [
-            10,
-            "Reduced Inequalities"
-          ],
-          [
-            11,
-            "Sustainable Cities and Communities"
-          ],
-          [
-            12,
-            "Responsible Consumption and Production"
-          ],
-          [
-            13,
-            "Climate Action"
-          ],
-          [
-            14,
-            "Life Below Water"
-          ],
-          [
-            15,
-            "Life On Land"
-          ],
-          [
-            16,
-            "Peace, Justice and Strong Institutions"
-          ],
-          [
-            17,
-            "Partnerships for the Goals"
-          ]
-        ]
+        "type": "object",
+        "required": [
+          "SDGNumber"
+        ],
+        "properties": {
+          "SDGNumber": {
+            "type": "number",
+            "description": "Number of the Sustainable Development Goal",
+            "enum": [
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+              17
+            ]
+          },
+          "evidenceText": {
+            "type": "string",
+            "description": "Evidence of SDG relevance in text form."
+          },
+          "evidenceURL": {
+            "type": "string",
+            "description": "Evidence of SDG relevance in the form of a link."
+          }
+        }
       }
     },
-    "SDGevidence": {
-      "type": "string",
-      "description": "Relevant links or information to support the relevance to SDGs."
-    }, 
     "sectors": {
       "type": "array",
       "description": "List of sectors that this Global Digital Public Good addresses.",


### PR DESCRIPTION
Added `SDGevidence` field to document relevance to the SDGs for each product as a string field that can contain both text and links (I admit this is messy, and should probably be split into different fields). Currently this field is optional because the effort to retroactively add this field to all existing products would be monumental, but we are requiring it for new products to be added. Eventually, we could make it required.